### PR TITLE
Current game selector, Internet archive source and apply all for xbox.com

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/AuroraAssetEditor/App.xaml.cs
+++ b/AuroraAssetEditor/App.xaml.cs
@@ -1,9 +1,9 @@
 ﻿//
-// 	App.xaml.cs
-// 	AuroraAssetEditor
+//  App.xaml.cs
+//  AuroraAssetEditor
 //
-// 	Created by Swizzy on 08/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 08/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor {
     using System.Drawing;

--- a/AuroraAssetEditor/Classes/AuroraAsset.cs
+++ b/AuroraAssetEditor/Classes/AuroraAsset.cs
@@ -1,9 +1,9 @@
 ﻿// 
-// 	AuroraAsset.cs
-// 	AuroraAssetEditor
+//  AuroraAsset.cs
+//  AuroraAssetEditor
 // 
-// 	Created by Swizzy on 04/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 04/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor.Classes {
     using System;

--- a/AuroraAssetEditor/Classes/AuroraAssetDll.cs
+++ b/AuroraAssetEditor/Classes/AuroraAssetDll.cs
@@ -81,15 +81,15 @@ namespace PhoenixTools
             {
                 Console.WriteLine(e.Message);
             }
-			finally {
-				// Clean up unmanaged file data
+            finally {
+                // Clean up unmanaged file data
                 if (pd != IntPtr.Zero)
                     Marshal.FreeHGlobal(pd);
                 if (hd != IntPtr.Zero)
                     Marshal.FreeHGlobal(hd);
                 if (vd != IntPtr.Zero)
                     Marshal.FreeHGlobal(vd);
-			}
+            }
 
             return false;
         }

--- a/AuroraAssetEditor/Classes/AuroraDbManager.cs
+++ b/AuroraAssetEditor/Classes/AuroraDbManager.cs
@@ -1,9 +1,9 @@
 ﻿// 
-// 	AuroraDbManager.cs
-// 	AuroraAssetEditor
+//  AuroraDbManager.cs
+//  AuroraAssetEditor
 // 
-// 	Created by Swizzy on 14/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 14/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor.Classes {
     using System;

--- a/AuroraAssetEditor/Classes/FSDAsset.cs
+++ b/AuroraAssetEditor/Classes/FSDAsset.cs
@@ -1,9 +1,9 @@
 ﻿// 
-// 	FSDAsset.cs
-// 	AuroraAssetEditor
+//  FSDAsset.cs
+//  AuroraAssetEditor
 // 
-// 	Created by Swizzy on 10/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 10/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor.Classes {
     using System;

--- a/AuroraAssetEditor/Classes/FTPOperations.cs
+++ b/AuroraAssetEditor/Classes/FTPOperations.cs
@@ -1,9 +1,9 @@
 ﻿// 
-// 	FTPOperations.cs
-// 	AuroraAssetEditor
+//  FTPOperations.cs
+//  AuroraAssetEditor
 // 
-// 	Created by Swizzy on 10/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 10/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor.Classes {
     using System;

--- a/AuroraAssetEditor/Classes/InternetArchiveAssetDownloader.cs
+++ b/AuroraAssetEditor/Classes/InternetArchiveAssetDownloader.cs
@@ -1,154 +1,151 @@
 ﻿//
-// 	InternetArchiveDownloader.cs
-// 	AuroraAssetEditor
+//  InternetArchiveDownloader.cs
+//  AuroraAssetEditor
 //
-// 	Created by aenrione
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by aenrione
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor.Classes
 {
-	using System;
-	using System.Collections.Generic;
-	using System.Drawing;
-	using System.Text.RegularExpressions;
-	using System.IO;
-	using System.Net;
-	using System.Text;
+    using System;
+    using System.Collections.Generic;
+    using System.Drawing;
+    using System.Text.RegularExpressions;
+    using System.IO;
+    using System.Net;
+    using System.Text;
 
-	internal class InternetArchiveDownloader
-	{
-		private const string BaseUrl = "https://archive.org/download/xboxunity-covers-fulldump_202311/xboxunity-covers-fulldump/";
-		public static EventHandler<StatusArgs> StatusChanged;
+    internal class InternetArchiveDownloader
+    {
+        private const string BaseUrl = "https://archive.org/download/xboxunity-covers-fulldump_202311/xboxunity-covers-fulldump/";
+        public static EventHandler<StatusArgs> StatusChanged;
 
-		internal static void SendStatusChanged(string msg)
-		{
-			var handler = StatusChanged;
-			if (handler != null)
-				handler.Invoke(null, new StatusArgs(msg));
-		}
+        internal static void SendStatusChanged(string msg)
+        {
+            var handler = StatusChanged;
+            if (handler != null)
+                handler.Invoke(null, new StatusArgs(msg));
+        }
 
-		public InternetArchiveAsset[] GetTitleInfo(uint titleId)
-		{
-			string titleFolder = string.Format("{0:X08}", titleId);
-			List<InternetArchiveAsset> assets = new List<InternetArchiveAsset>();
+        public InternetArchiveAsset[] GetTitleInfo(uint titleId)
+        {
+            string titleFolder = string.Format("{0:X08}", titleId);
+            List<InternetArchiveAsset> assets = new List<InternetArchiveAsset>();
 
-			try
-			{
-				using (WebClient client = new WebClient())
-				{
-					string folderUrl = $"{BaseUrl}{titleFolder}/";
-					string htmlContent = client.DownloadString(folderUrl);
+            try
+            {
+                using (WebClient client = new WebClient())
+                {
+                    string folderUrl = $"{BaseUrl}{titleFolder}/";
+                    string htmlContent = client.DownloadString(folderUrl);
 
-					foreach (string subDir in ParseDirectoriesFromHtmlRegex(htmlContent))
-					{
-						assets.Add(new InternetArchiveAsset
-						{
-							TitleId = titleId,
-							MainFolder = titleFolder,
-							SubFolder = subDir,
-							AssetType = "Cover"
-						});
-					}
-				}
-			}
-			catch (Exception ex)
-			{
-				SendStatusChanged($"Error fetching directory: {ex.Message}");
-			}
+                    foreach (string subDir in ParseDirectoriesFromHtmlRegex(htmlContent))
+                    {
+                        assets.Add(new InternetArchiveAsset
+                        {
+                            TitleId = titleId,
+                            MainFolder = titleFolder,
+                            SubFolder = subDir,
+                            AssetType = "Cover"
+                        });
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                SendStatusChanged($"Error fetching directory: {ex.Message}");
+            }
 
-			return assets.ToArray();
-		}
+            return assets.ToArray();
+        }
 
-		private IEnumerable<string> ParseDirectoriesFromHtmlRegex(string html)
-		{
-			const string HREF_REGEX = "<a href=\"(.+)/\">(.+)/</a>";
-			
-			foreach (Match match in Regex.Matches(html, HREF_REGEX))
-			{
-				var hrefValue = match.Groups[1].Value;
-				var text = match.Groups[2].Value;
+        private IEnumerable<string> ParseDirectoriesFromHtmlRegex(string html)
+        {
+            const string HREF_REGEX = "<a href=\"(.+)/\">(.+)/</a>";
+            
+            foreach (Match match in Regex.Matches(html, HREF_REGEX))
+            {
+                var hrefValue = match.Groups[1].Value;
+                var text = match.Groups[2].Value;
 
-				if (hrefValue == text)
-				{
-					yield return hrefValue;
-				}
-			}
-		}
+                if (hrefValue == text)
+                {
+                    yield return hrefValue;
+                }
+            }
+        }
 
-		public Image DownloadCover(InternetArchiveAsset asset)
-		{
-			try
-			{
-				string coverUrl = $"{BaseUrl}{asset.MainFolder}/{asset.SubFolder}/boxart.png";
-				using (WebClient wc = new WebClient())
-				{
-					byte[] imageData = wc.DownloadData(coverUrl);
+        public Image DownloadCover(InternetArchiveAsset asset)
+        {
+            try
+            {
+                string coverUrl = $"{BaseUrl}{asset.MainFolder}/{asset.SubFolder}/boxart.png";
+                using (WebClient wc = new WebClient())
+                {
+                    byte[] imageData = wc.DownloadData(coverUrl);
 
-					if (imageData == null || imageData.Length == 0)
-					{
-						SendStatusChanged("No image data received");
-						return null;
-					}
+                    if (imageData == null || imageData.Length == 0)
+                    {
+                        SendStatusChanged("No image data received");
+                        return null;
+                    }
 
-					MemoryStream ms = new MemoryStream(imageData);
+                    MemoryStream ms = new MemoryStream(imageData);
 
-					try
-					{
-						using (Image originalImage = Image.FromStream(ms, true, true))
-						{
-							return new Bitmap(originalImage);
-						}
-					}
-					finally
-					{
-						ms.Dispose();
-					}
-				}
-			}
-			catch (WebException webEx)
-			{
-				SendStatusChanged($"Network error downloading cover: {webEx.Message}");
-				return null;
-			}
-			catch (ArgumentException argEx)
-			{
-				SendStatusChanged($"Invalid image data received: {argEx.Message}");
-				return null;
-			}
-			catch (Exception ex)
-			{
-				SendStatusChanged($"Error downloading cover: {ex.Message}");
-				return null;
-			}
-		}
+                    try
+                    {
+                        using (Image originalImage = Image.FromStream(ms, true, true))
+                        {
+                            return new Bitmap(originalImage);
+                        }
+                    }
+                    finally
+                    {
+                        ms.Dispose();
+                    }
+                }
+            }
+            catch (WebException webEx)
+            {
+                SendStatusChanged($"Network error downloading cover: {webEx.Message}");
+                return null;
+            }
+            catch (ArgumentException argEx)
+            {
+                SendStatusChanged($"Invalid image data received: {argEx.Message}");
+                return null;
+            }
+            catch (Exception ex)
+            {
+                SendStatusChanged($"Error downloading cover: {ex.Message}");
+                return null;
+            }
+        }
+    }
 
-	}
+    // Modified asset class to handle the nested structure
+    public class InternetArchiveAsset
+    {
+        private Image _cover;
+        public uint TitleId { get; set; }
+        public string MainFolder { get; set; }  // The title ID folder
+        public string SubFolder { get; set; }   // The subfolder containing the actual cover
+        public string AssetType { get; set; }
+        public bool HaveAsset { get { return _cover != null; } }
 
-	// Modified asset class to handle the nested structure
-	public class InternetArchiveAsset
-	{
-		private Image _cover;
-		public uint TitleId { get; set; }
-		public string MainFolder { get; set; }  // The title ID folder
-		public string SubFolder { get; set; }   // The subfolder containing the actual cover
-		public string AssetType { get; set; }
-		public bool HaveAsset { get { return _cover != null; } }
+        public Image GetCover()
+        {
+            if (_cover == null)
+            {
+                var downloader = new InternetArchiveDownloader();
+                _cover = downloader.DownloadCover(this);
+            }
+            return _cover;
+        }
 
-		public Image GetCover()
-		{
-			if (_cover == null)
-			{
-				var downloader = new InternetArchiveDownloader();
-				_cover = downloader.DownloadCover(this);
-
-			}
-			return _cover;
-		}
-
-		public override string ToString()
-		{
-			return $"TitleID: {TitleId:X8} - Variant: {SubFolder}";
-		}
-	}
-
+        public override string ToString()
+        {
+            return $"TitleID: {TitleId:X8} - Variant: {SubFolder}";
+        }
+    }
 }

--- a/AuroraAssetEditor/Classes/InternetArchiveAssetDownloader.cs
+++ b/AuroraAssetEditor/Classes/InternetArchiveAssetDownloader.cs
@@ -1,0 +1,154 @@
+﻿//
+// 	InternetArchiveDownloader.cs
+// 	AuroraAssetEditor
+//
+// 	Created by aenrione
+// 	Copyright (c) 2015 Swizzy. All rights reserved.
+
+namespace AuroraAssetEditor.Classes
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Drawing;
+	using System.Text.RegularExpressions;
+	using System.IO;
+	using System.Net;
+	using System.Text;
+
+	internal class InternetArchiveDownloader
+	{
+		private const string BaseUrl = "https://archive.org/download/xboxunity-covers-fulldump_202311/xboxunity-covers-fulldump/";
+		public static EventHandler<StatusArgs> StatusChanged;
+
+		internal static void SendStatusChanged(string msg)
+		{
+			var handler = StatusChanged;
+			if (handler != null)
+				handler.Invoke(null, new StatusArgs(msg));
+		}
+
+		public InternetArchiveAsset[] GetTitleInfo(uint titleId)
+		{
+			string titleFolder = string.Format("{0:X08}", titleId);
+			List<InternetArchiveAsset> assets = new List<InternetArchiveAsset>();
+
+			try
+			{
+				using (WebClient client = new WebClient())
+				{
+					string folderUrl = $"{BaseUrl}{titleFolder}/";
+					string htmlContent = client.DownloadString(folderUrl);
+
+					foreach (string subDir in ParseDirectoriesFromHtmlRegex(htmlContent))
+					{
+						assets.Add(new InternetArchiveAsset
+						{
+							TitleId = titleId,
+							MainFolder = titleFolder,
+							SubFolder = subDir,
+							AssetType = "Cover"
+						});
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				SendStatusChanged($"Error fetching directory: {ex.Message}");
+			}
+
+			return assets.ToArray();
+		}
+
+		private IEnumerable<string> ParseDirectoriesFromHtmlRegex(string html)
+		{
+			const string HREF_REGEX = "<a href=\"(.+)/\">(.+)/</a>";
+			
+			foreach (Match match in Regex.Matches(html, HREF_REGEX))
+			{
+				var hrefValue = match.Groups[1].Value;
+				var text = match.Groups[2].Value;
+
+				if (hrefValue == text)
+				{
+					yield return hrefValue;
+				}
+			}
+		}
+
+		public Image DownloadCover(InternetArchiveAsset asset)
+		{
+			try
+			{
+				string coverUrl = $"{BaseUrl}{asset.MainFolder}/{asset.SubFolder}/boxart.png";
+				using (WebClient wc = new WebClient())
+				{
+					byte[] imageData = wc.DownloadData(coverUrl);
+
+					if (imageData == null || imageData.Length == 0)
+					{
+						SendStatusChanged("No image data received");
+						return null;
+					}
+
+					MemoryStream ms = new MemoryStream(imageData);
+
+					try
+					{
+						using (Image originalImage = Image.FromStream(ms, true, true))
+						{
+							return new Bitmap(originalImage);
+						}
+					}
+					finally
+					{
+						ms.Dispose();
+					}
+				}
+			}
+			catch (WebException webEx)
+			{
+				SendStatusChanged($"Network error downloading cover: {webEx.Message}");
+				return null;
+			}
+			catch (ArgumentException argEx)
+			{
+				SendStatusChanged($"Invalid image data received: {argEx.Message}");
+				return null;
+			}
+			catch (Exception ex)
+			{
+				SendStatusChanged($"Error downloading cover: {ex.Message}");
+				return null;
+			}
+		}
+
+	}
+
+	// Modified asset class to handle the nested structure
+	public class InternetArchiveAsset
+	{
+		private Image _cover;
+		public uint TitleId { get; set; }
+		public string MainFolder { get; set; }  // The title ID folder
+		public string SubFolder { get; set; }   // The subfolder containing the actual cover
+		public string AssetType { get; set; }
+		public bool HaveAsset { get { return _cover != null; } }
+
+		public Image GetCover()
+		{
+			if (_cover == null)
+			{
+				var downloader = new InternetArchiveDownloader();
+				_cover = downloader.DownloadCover(this);
+
+			}
+			return _cover;
+		}
+
+		public override string ToString()
+		{
+			return $"TitleID: {TitleId:X8} - Variant: {SubFolder}";
+		}
+	}
+
+}

--- a/AuroraAssetEditor/Classes/StatusArgs.cs
+++ b/AuroraAssetEditor/Classes/StatusArgs.cs
@@ -1,9 +1,9 @@
 ﻿// 
-// 	StatusArgs.cs
-// 	AuroraAssetEditor
+//  StatusArgs.cs
+//  AuroraAssetEditor
 // 
-// 	Created by Swizzy on 10/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 10/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor.Classes {
     using System;

--- a/AuroraAssetEditor/Classes/ThreadSafeObservableCollection.cs
+++ b/AuroraAssetEditor/Classes/ThreadSafeObservableCollection.cs
@@ -1,9 +1,9 @@
 ﻿// 
-// 	ThreadSafeObservableCollection.cs
-// 	AuroraAssetEditor
+//  ThreadSafeObservableCollection.cs
+//  AuroraAssetEditor
 // 
-// 	Created by Swizzy on 14/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 14/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor.Classes {
     using System.Collections.ObjectModel;

--- a/AuroraAssetEditor/Classes/XboxAssetDownloader.cs
+++ b/AuroraAssetEditor/Classes/XboxAssetDownloader.cs
@@ -1,9 +1,9 @@
 ﻿//
-// 	XboxAssetDownloader.cs
-// 	AuroraAssetEditor
+//  XboxAssetDownloader.cs
+//  AuroraAssetEditor
 //
-// 	Created by Swizzy on 10/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 10/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor.Classes {
     using System;

--- a/AuroraAssetEditor/Classes/XboxUnity.cs
+++ b/AuroraAssetEditor/Classes/XboxUnity.cs
@@ -1,9 +1,9 @@
 ﻿// 
-// 	XboxUnity.cs
-// 	AuroraAssetEditor
+//  XboxUnity.cs
+//  AuroraAssetEditor
 // 
-// 	Created by Swizzy on 10/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 10/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor.Classes {
     using System;

--- a/AuroraAssetEditor/Controls/BackgroundControl.xaml.cs
+++ b/AuroraAssetEditor/Controls/BackgroundControl.xaml.cs
@@ -1,9 +1,9 @@
 ﻿//
-// 	BackgroundControl.xaml.cs
-// 	AuroraAssetEditor
+//  BackgroundControl.xaml.cs
+//  AuroraAssetEditor
 //
-// 	Created by Swizzy on 10/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 10/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor.Controls {
     using System;

--- a/AuroraAssetEditor/Controls/BoxartControl.xaml.cs
+++ b/AuroraAssetEditor/Controls/BoxartControl.xaml.cs
@@ -1,9 +1,9 @@
 ﻿//
-// 	BoxartControl.xaml.cs
-// 	AuroraAssetEditor
+//  BoxartControl.xaml.cs
+//  AuroraAssetEditor
 //
-// 	Created by Swizzy on 10/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 10/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor.Controls {
     using System;

--- a/AuroraAssetEditor/Controls/CircularProgressBar.xaml.cs
+++ b/AuroraAssetEditor/Controls/CircularProgressBar.xaml.cs
@@ -1,9 +1,9 @@
 ﻿// 
-// 	CircularProgressBar.xaml.cs
-// 	AuroraAssetEditor
+//  CircularProgressBar.xaml.cs
+//  AuroraAssetEditor
 // 
-// 	Created by Swizzy on 10/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 10/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor.Controls {
     using System;

--- a/AuroraAssetEditor/Controls/FtpAssetsControl.xaml
+++ b/AuroraAssetEditor/Controls/FtpAssetsControl.xaml
@@ -70,6 +70,7 @@
                     <TextBox x:Name="TitleIdFilterBox" TextChanged="TitleIdFilterChanged"/>
                 </GroupBox>
                 <DataGrid x:Name="FtpAssetsBox"
+                          SelectionChanged="FtpAssetsBox_SelectionChanged"
                           IsTextSearchEnabled="False"
                           AlternationCount="2"
                           AutoGenerateColumns="False"

--- a/AuroraAssetEditor/Controls/FtpAssetsControl.xaml.cs
+++ b/AuroraAssetEditor/Controls/FtpAssetsControl.xaml.cs
@@ -17,11 +17,13 @@ namespace AuroraAssetEditor.Controls {
     using System.Windows.Controls;
 	using System.Windows.Data;
 	using System.Windows.Threading;
-    using Classes;
+	using AuroraAssetEditor.Models;
+	using Classes;
+	using Helpers;
 
-    /// <summary>
-    ///     Interaction logic for FtpAssetsControl.xaml
-    /// </summary>
+	/// <summary>
+	///     Interaction logic for FtpAssetsControl.xaml
+	/// </summary>
     public partial class FtpAssetsControl {
 		private readonly ThreadSafeObservableCollection<AuroraDbManager.ContentItem> _assetsList = new ThreadSafeObservableCollection<AuroraDbManager.ContentItem>();
 		private readonly CollectionViewSource _assetsViewSource = new CollectionViewSource();
@@ -86,7 +88,24 @@ namespace AuroraAssetEditor.Controls {
             bw.RunWorkerAsync();
         }
 
-        private void SaveSettingsClick(object sender, RoutedEventArgs e) { App.FtpOperations.SaveSettings(IpBox.Text, UserBox.Text, PassBox.Text, PortBox.Text); }
+		private void FtpAssetsBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+		{
+			if (FtpAssetsBox.SelectedItem is Classes.AuroraDbManager.ContentItem selectedAsset)
+			{
+				var newGame = new Game
+				{
+					Title = selectedAsset.TitleName,
+					TitleId = selectedAsset.TitleId,
+					DbId = selectedAsset.DatabaseId,
+					IsGameSelected = true
+				};
+
+				GlobalState.CurrentGame = newGame;
+			}
+		}
+
+
+		private void SaveSettingsClick(object sender, RoutedEventArgs e) { App.FtpOperations.SaveSettings(IpBox.Text, UserBox.Text, PassBox.Text, PortBox.Text); }
 
         private void GetAssetsClick(object sender, RoutedEventArgs e) {
             _assetsList.Clear();

--- a/AuroraAssetEditor/Controls/FtpAssetsControl.xaml.cs
+++ b/AuroraAssetEditor/Controls/FtpAssetsControl.xaml.cs
@@ -1,9 +1,9 @@
 ﻿//
-// 	FtpAssetsControl.xaml.cs
-// 	AuroraAssetEditor
+//  FtpAssetsControl.xaml.cs
+//  AuroraAssetEditor
 //
-// 	Created by Swizzy on 13/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 13/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor.Controls {
     using System;
@@ -15,20 +15,20 @@ namespace AuroraAssetEditor.Controls {
     using System.Threading;
     using System.Windows;
     using System.Windows.Controls;
-	using System.Windows.Data;
-	using System.Windows.Threading;
-	using AuroraAssetEditor.Models;
-	using Classes;
-	using Helpers;
+    using System.Windows.Data;
+    using System.Windows.Threading;
+    using AuroraAssetEditor.Models;
+    using Classes;
+    using Helpers;
 
-	/// <summary>
-	///     Interaction logic for FtpAssetsControl.xaml
-	/// </summary>
+    /// <summary>
+    ///     Interaction logic for FtpAssetsControl.xaml
+    /// </summary>
     public partial class FtpAssetsControl {
-		private readonly ThreadSafeObservableCollection<AuroraDbManager.ContentItem> _assetsList = new ThreadSafeObservableCollection<AuroraDbManager.ContentItem>();
-		private readonly CollectionViewSource _assetsViewSource = new CollectionViewSource();
-		private readonly ICollectionView _assetView;
-		private readonly BackgroundControl _background;
+        private readonly ThreadSafeObservableCollection<AuroraDbManager.ContentItem> _assetsList = new ThreadSafeObservableCollection<AuroraDbManager.ContentItem>();
+        private readonly CollectionViewSource _assetsViewSource = new CollectionViewSource();
+        private readonly ICollectionView _assetView;
+        private readonly BackgroundControl _background;
         private readonly BoxartControl _boxart;
         private readonly IconBannerControl _iconBanner;
         private readonly MainWindow _main;
@@ -38,8 +38,8 @@ namespace AuroraAssetEditor.Controls {
 
         public FtpAssetsControl(MainWindow main, BoxartControl boxart, BackgroundControl background, IconBannerControl iconBanner, ScreenshotsControl screenshots) {
             InitializeComponent();
-			_assetsViewSource.Source = _assetsList;
-			_main = main;
+            _assetsViewSource.Source = _assetsList;
+            _main = main;
             _boxart = boxart;
             _background = background;
             _iconBanner = iconBanner;
@@ -88,24 +88,23 @@ namespace AuroraAssetEditor.Controls {
             bw.RunWorkerAsync();
         }
 
-		private void FtpAssetsBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-		{
-			if (FtpAssetsBox.SelectedItem is Classes.AuroraDbManager.ContentItem selectedAsset)
-			{
-				var newGame = new Game
-				{
-					Title = selectedAsset.TitleName,
-					TitleId = selectedAsset.TitleId,
-					DbId = selectedAsset.DatabaseId,
-					IsGameSelected = true
-				};
+        private void SaveSettingsClick(object sender, RoutedEventArgs e) { App.FtpOperations.SaveSettings(IpBox.Text, UserBox.Text, PassBox.Text, PortBox.Text); }
 
-				GlobalState.CurrentGame = newGame;
-			}
-		}
+        private void FtpAssetsBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (FtpAssetsBox.SelectedItem is Classes.AuroraDbManager.ContentItem selectedAsset)
+            {
+                var newGame = new Game
+                {
+                    Title = selectedAsset.TitleName,
+                    TitleId = selectedAsset.TitleId,
+                    DbId = selectedAsset.DatabaseId,
+                    IsGameSelected = true
+                };
 
-
-		private void SaveSettingsClick(object sender, RoutedEventArgs e) { App.FtpOperations.SaveSettings(IpBox.Text, UserBox.Text, PassBox.Text, PortBox.Text); }
+                GlobalState.CurrentGame = newGame;
+            }
+        }
 
         private void GetAssetsClick(object sender, RoutedEventArgs e) {
             _assetsList.Clear();
@@ -376,28 +375,28 @@ namespace AuroraAssetEditor.Controls {
             SaveScreenshotsClick(sender, e);
         }
 
-		private void TitleFilterChanged(Object sender, TextChangedEventArgs e) => FiltersChanged(TitleFilterBox.Text, TitleIdFilterBox.Text);
+        private void TitleFilterChanged(Object sender, TextChangedEventArgs e) => FiltersChanged(TitleFilterBox.Text, TitleIdFilterBox.Text);
 
-		private void TitleIdFilterChanged(Object sender, TextChangedEventArgs e) => FiltersChanged(TitleFilterBox.Text, TitleIdFilterBox.Text);
+        private void TitleIdFilterChanged(Object sender, TextChangedEventArgs e) => FiltersChanged(TitleFilterBox.Text, TitleIdFilterBox.Text);
 
-		private void FiltersChanged(string titleFilter, string titleIdFilter)
-		{
-			_assetView.Filter = item =>
-			{
-				var contentItem = item as AuroraDbManager.ContentItem;
-				if (contentItem == null)
-					return false;
-				if (string.IsNullOrWhiteSpace(titleFilter) && string.IsNullOrWhiteSpace(titleIdFilter))
-					return true;
-				if (!string.IsNullOrWhiteSpace(titleFilter) && !string.IsNullOrWhiteSpace(titleIdFilter))
-					return contentItem.TitleName.ToLower().Contains(titleFilter.ToLower()) && contentItem.TitleId.ToLower().Contains(titleIdFilter.ToLower());
-				if (!string.IsNullOrWhiteSpace(titleFilter))
-					return contentItem.TitleName.ToLower().Contains(titleFilter.ToLower());
-				return contentItem.TitleId.ToLower().Contains(titleIdFilter.ToLower());
-			};
-		}
+        private void FiltersChanged(string titleFilter, string titleIdFilter)
+        {
+            _assetView.Filter = item =>
+            {
+                var contentItem = item as AuroraDbManager.ContentItem;
+                if (contentItem == null)
+                    return false;
+                if (string.IsNullOrWhiteSpace(titleFilter) && string.IsNullOrWhiteSpace(titleIdFilter))
+                    return true;
+                if (!string.IsNullOrWhiteSpace(titleFilter) && !string.IsNullOrWhiteSpace(titleIdFilter))
+                    return contentItem.TitleName.ToLower().Contains(titleFilter.ToLower()) && contentItem.TitleId.ToLower().Contains(titleIdFilter.ToLower());
+                if (!string.IsNullOrWhiteSpace(titleFilter))
+                    return contentItem.TitleName.ToLower().Contains(titleFilter.ToLower());
+                return contentItem.TitleId.ToLower().Contains(titleIdFilter.ToLower());
+            };
+        }
 
-		private enum Task {
+        private enum Task {
             GetBoxart,
             GetBackground,
             GetIconBanner,

--- a/AuroraAssetEditor/Controls/IconBannerControl.xaml.cs
+++ b/AuroraAssetEditor/Controls/IconBannerControl.xaml.cs
@@ -1,9 +1,9 @@
 ﻿//
-// 	IconBannerControl.xaml.cs
-// 	AuroraAssetEditor
+//  IconBannerControl.xaml.cs
+//  AuroraAssetEditor
 //
-// 	Created by Swizzy on 10/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 10/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor.Controls {
     using System;

--- a/AuroraAssetEditor/Controls/OnlineAssetsControl.xaml
+++ b/AuroraAssetEditor/Controls/OnlineAssetsControl.xaml
@@ -25,6 +25,7 @@
             <ComboBox x:Name="SourceBox" Grid.Row="0" Grid.Column="1" Width="150" HorizontalAlignment="Left"
                       Margin="0, 10, 0, 10" SelectionChanged="SourceBox_SelectionChanged">
                 <ComboBoxItem Content="Xboxunity.net" />
+                <ComboBoxItem>Internet Archive</ComboBoxItem>
             </ComboBox>
             <Grid Grid.Row="0" Grid.Column="2" Visibility="Hidden" x:Name="LocaleGrid">
                 <Grid.ColumnDefinitions>
@@ -52,11 +53,18 @@
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
                 <Button Grid.Column="0" Content="Search by TitleID" Margin="10" Padding="10, 5, 10, 5"
                         Click="ByTitleIdClick" />
                 <Button x:Name="KeywordsButton" Grid.Column="1" Content="Search by Keywords" Margin="10"
                         Padding="10, 5, 10, 5" Click="ByKeywordsClick" />
+                <Button x:Name="DownloadAllButton"
+                    Margin="10" Padding="10, 5, 10, 5"
+                    Grid.Column="2"
+                    Content="Apply All Assets" 
+                    Click="DownloadAllButton_Click"
+                    Visibility="Hidden"/>
             </Grid>
         </Grid>
         <Grid Row="1">

--- a/AuroraAssetEditor/Controls/OnlineAssetsControl.xaml
+++ b/AuroraAssetEditor/Controls/OnlineAssetsControl.xaml
@@ -60,11 +60,12 @@
                 <Button x:Name="KeywordsButton" Grid.Column="1" Content="Search by Keywords" Margin="10"
                         Padding="10, 5, 10, 5" Click="ByKeywordsClick" />
                 <Button x:Name="DownloadAllButton"
-                    Margin="10" Padding="10, 5, 10, 5"
-                    Grid.Column="2"
-                    Content="Apply All Assets" 
-                    Click="DownloadAllButton_Click"
-                    Visibility="Hidden"/>
+                        Margin="10"
+                        Padding="10, 5, 10, 5"
+                        Grid.Column="2"
+                        Content="Apply All Assets" 
+                        Click="DownloadAllButton_Click"
+                        Visibility="Hidden"/>
             </Grid>
         </Grid>
         <Grid Row="1">

--- a/AuroraAssetEditor/Controls/OnlineAssetsControl.xaml.cs
+++ b/AuroraAssetEditor/Controls/OnlineAssetsControl.xaml.cs
@@ -1,9 +1,9 @@
 ﻿//
-// 	OnlineAssetsControl.xaml.cs
-// 	AuroraAssetEditor
+//  OnlineAssetsControl.xaml.cs
+//  AuroraAssetEditor
 //
-// 	Created by Swizzy on 10/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 10/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor.Controls {
     using System;
@@ -12,27 +12,27 @@ namespace AuroraAssetEditor.Controls {
     using System.Drawing.Imaging;
     using System.Globalization;
     using System.IO;
-	using System.Text.RegularExpressions;
+    using System.Text.RegularExpressions;
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Input;
     using System.Windows.Media.Imaging;
-	using AuroraAssetEditor.Helpers;
-	using Classes;
-	using System.Linq;
-	using Image = System.Drawing.Image;
+    using AuroraAssetEditor.Helpers;
+    using Classes;
+    using System.Linq;
+    using Image = System.Drawing.Image;
 
     /// <summary>
     ///     Interaction logic for OnlineAssetsControl.xaml
     /// </summary>
     public partial class OnlineAssetsControl {
-		private enum OnlineAssetSources
-		{
-			XboxUnityOption = 0,
-			ArchiveOption = 1,
-			XboxComOption = 2
-		}
-		private readonly BackgroundControl _background;
+        private enum OnlineAssetSources
+        {
+            XboxUnityOption = 0,
+            ArchiveOption = 1,
+            XboxComOption = 2
+        }
+        private readonly BackgroundControl _background;
         private readonly UIElement[] _backgroundMenu;
         private readonly UIElement[] _bannerMenu;
         private readonly BoxartControl _boxart;
@@ -45,20 +45,19 @@ namespace AuroraAssetEditor.Controls {
         private readonly BackgroundWorker _unityWorker = new BackgroundWorker();
         private readonly XboxAssetDownloader _xboxAssetDownloader = new XboxAssetDownloader();
         private readonly BackgroundWorker _xboxWorker = new BackgroundWorker();
-		private BackgroundWorker _archiveWorker;
-		private InternetArchiveDownloader _archiveDownloader;
-		private Image _img;
+        private BackgroundWorker _archiveWorker;
+        private InternetArchiveDownloader _archiveDownloader;
+        private Image _img;
         private string _keywords;
         private XboxLocale[] _locales;
         private uint _titleId;
         private XboxUnity.XboxUnityAsset[] _unityResult;
         private XboxTitleInfo[] _xboxResult;
-		private InternetArchiveAsset[] _archiveResult;
+        private InternetArchiveAsset[] _archiveResult;
 
-
-		public OnlineAssetsControl(MainWindow main, BoxartControl boxart, BackgroundControl background, IconBannerControl iconBanner, ScreenshotsControl screenshots) {
+        public OnlineAssetsControl(MainWindow main, BoxartControl boxart, BackgroundControl background, IconBannerControl iconBanner, ScreenshotsControl screenshots) {
             InitializeComponent();
-			GlobalState.GameChanged += OnGameChanged;
+            GlobalState.GameChanged += OnGameChanged;
             XboxAssetDownloader.StatusChanged += StatusChanged;
             _main = main;
             _boxart = boxart;
@@ -137,7 +136,7 @@ namespace AuroraAssetEditor.Controls {
                                                           disp.AddRange(info.AssetsInfo);
                                                       ResultBox.ItemsSource = disp;
                                                       SearchResultCount.Text = disp.Count.ToString(CultureInfo.InvariantCulture);
-													  DownloadAllButton.Visibility = Visibility.Visible;
+                                                      DownloadAllButton.Visibility = Visibility.Visible;
                                                   }
                                                   else {
                                                       ResultBox.ItemsSource = null;
@@ -145,50 +144,50 @@ namespace AuroraAssetEditor.Controls {
                                                   }
                                               };
 
-			#endregion
+            #endregion
 
-			#region Internet Archive Worker
+            #region Internet Archive Worker
 
-			_archiveWorker = new BackgroundWorker();
-			_archiveDownloader = new InternetArchiveDownloader();
+            _archiveWorker = new BackgroundWorker();
+            _archiveDownloader = new InternetArchiveDownloader();
 
-			_archiveWorker.DoWork += (sender, args) =>
-			{
-				try
-				{
-					uint titleId = (uint)args.Argument;
-					_archiveResult = _archiveDownloader.GetTitleInfo(titleId);
-					Dispatcher.Invoke(new Action(() => StatusMessage.Text = "Finished retrieving asset information..."));
-					args.Result = true;
-				}
-				catch (Exception ex)
-				{
-					MainWindow.SaveError(ex);
-					Dispatcher.Invoke(new Action(() => StatusMessage.Text = "An error has occurred, check error.log for more information..."));
-					args.Result = false;
-				}
-			};
+            _archiveWorker.DoWork += (sender, args) =>
+            {
+                try
+                {
+                    uint titleId = (uint)args.Argument;
+                    _archiveResult = _archiveDownloader.GetTitleInfo(titleId);
+                    Dispatcher.Invoke(new Action(() => StatusMessage.Text = "Finished retrieving asset information..."));
+                    args.Result = true;
+                }
+                catch (Exception ex)
+                {
+                    MainWindow.SaveError(ex);
+                    Dispatcher.Invoke(new Action(() => StatusMessage.Text = "An error has occurred, check error.log for more information..."));
+                    args.Result = false;
+                }
+            };
 
-			_archiveWorker.RunWorkerCompleted += (sender, args) =>
-			{
-				if ((bool)args.Result)
-				{
-					ResultBox.ItemsSource = _archiveResult;
-					SearchResultCount.Text = _archiveResult.Length.ToString(CultureInfo.InvariantCulture);
-				}
-				else
-				{
-					ResultBox.ItemsSource = null;
-					SearchResultCount.Text = "0";
-				}
-			};
+            _archiveWorker.RunWorkerCompleted += (sender, args) =>
+            {
+                if ((bool)args.Result)
+                {
+                    ResultBox.ItemsSource = _archiveResult;
+                    SearchResultCount.Text = _archiveResult.Length.ToString(CultureInfo.InvariantCulture);
+                }
+                else
+                {
+                    ResultBox.ItemsSource = null;
+                    SearchResultCount.Text = "0";
+                }
+            };
 
-			#endregion
+            #endregion
 
 
-			#region Cover Menu
+            #region Cover Menu
 
-			_coverMenu = new UIElement[] {
+            _coverMenu = new UIElement[] {
                                              new MenuItem {
                                                               Header = "Save cover to file"
                                                           },
@@ -270,53 +269,53 @@ namespace AuroraAssetEditor.Controls {
 
         private void StatusChanged(object sender, StatusArgs e) { Dispatcher.Invoke(new Action(() => StatusMessage.Text = e.StatusMessage)); }
 
-		private void OnGameChanged() {
-			Dispatcher.Invoke(() =>
-			{
-				TitleIdBox.Text = GlobalState.CurrentGame.TitleId;
-			});
-		}
+        private void OnGameChanged() {
+            Dispatcher.Invoke(() =>
+            {
+                TitleIdBox.Text = GlobalState.CurrentGame.TitleId;
+            });
+        }
 
         private void OnPreviewTextInput(object sender, TextCompositionEventArgs e) { e.Handled = !uint.TryParse(e.Text, NumberStyles.HexNumber, CultureInfo.CurrentCulture, out _titleId); }
 
         private void SourceBox_SelectionChanged(object sender, SelectionChangedEventArgs e) {
             LocaleGrid.Visibility = SourceBox.SelectedIndex == (int) OnlineAssetSources.XboxComOption ? Visibility.Visible : Visibility.Hidden;
-			KeywordsButton.Visibility = SourceBox.SelectedIndex == (int) OnlineAssetSources.ArchiveOption ? Visibility.Hidden : Visibility.Visible;
-			KeywordsBox.Visibility = SourceBox.SelectedIndex == (int)OnlineAssetSources.ArchiveOption ? Visibility.Hidden : Visibility.Visible;
-			DownloadAllButton.Visibility = Visibility.Hidden;
+            KeywordsButton.Visibility = SourceBox.SelectedIndex == (int) OnlineAssetSources.ArchiveOption ? Visibility.Hidden : Visibility.Visible;
+            KeywordsBox.Visibility = SourceBox.SelectedIndex == (int)OnlineAssetSources.ArchiveOption ? Visibility.Hidden : Visibility.Visible;
+            DownloadAllButton.Visibility = Visibility.Hidden;
 
-		}
+        }
 
-		private void ByTitleIdClick(object sender, RoutedEventArgs e)
-		{
-			uint.TryParse(TitleIdBox.Text, NumberStyles.HexNumber, CultureInfo.CurrentCulture, out _titleId);
-			if (_unityWorker.IsBusy || _xboxWorker.IsBusy || _archiveWorker.IsBusy)
-			{
-				MessageBox.Show("Please wait for previous operation to complete!");
-				return;
-			}
-			PreviewImg.Source = null;
-			PreviewImg.ContextMenu.ItemsSource = null;
-			_main.EditMenu.ItemsSource = null;
-			_keywords = null;
+        private void ByTitleIdClick(object sender, RoutedEventArgs e)
+        {
+            uint.TryParse(TitleIdBox.Text, NumberStyles.HexNumber, CultureInfo.CurrentCulture, out _titleId);
+            if (_unityWorker.IsBusy || _xboxWorker.IsBusy || _archiveWorker.IsBusy)
+            {
+                MessageBox.Show("Please wait for previous operation to complete!");
+                return;
+            }
+            PreviewImg.Source = null;
+            PreviewImg.ContextMenu.ItemsSource = null;
+            _main.EditMenu.ItemsSource = null;
+            _keywords = null;
 
-			switch (SourceBox.SelectedIndex)
-			{
-				case 0:
-					StatusMessage.Text = "Downloading asset information...";
-					_unityWorker.RunWorkerAsync(_titleId.ToString("X08"));
-					break;
-				case 2:
-					_xboxWorker.RunWorkerAsync(LocaleBox.SelectedItem);
-					break;
-				case 1:
-					StatusMessage.Text = "Downloading cover from Internet Archive...";
-					_archiveWorker.RunWorkerAsync(_titleId);
-					break;
-			}
-		}
+            switch (SourceBox.SelectedIndex)
+            {
+                case 0:
+                    StatusMessage.Text = "Downloading asset information...";
+                    _unityWorker.RunWorkerAsync(_titleId.ToString("X08"));
+                    break;
+                case 2:
+                    _xboxWorker.RunWorkerAsync(LocaleBox.SelectedItem);
+                    break;
+                case 1:
+                    StatusMessage.Text = "Downloading cover from Internet Archive...";
+                    _archiveWorker.RunWorkerAsync(_titleId);
+                    break;
+            }
+        }
 
-		private void ByKeywordsClick(object sender, RoutedEventArgs e) {
+        private void ByKeywordsClick(object sender, RoutedEventArgs e) {
             if(_unityWorker.IsBusy || _xboxWorker.IsBusy) {
                 MessageBox.Show("Please wait for previous operation to complete!");
                 return;
@@ -378,91 +377,91 @@ namespace AuroraAssetEditor.Controls {
             else {
                 var xbox = ResultBox.SelectedItem as XboxTitleInfo.XboxAssetInfo;
                 if(xbox != null) {
-					if (!xbox.HaveAsset)
-					{
-						PreviewImg.Source = null;
-						StatusMessage.Text = "Downloading asset data...";
-						var bw = new BackgroundWorker();
-						bw.DoWork += (o, args) => {
-							var asset = args.Argument as XboxTitleInfo.XboxAssetInfo;
-							if (asset != null)
-								asset.GetAsset();
-						};
-						bw.RunWorkerCompleted += (o, args) => {
-							StatusMessage.Text = "Finished downloading asset data...";
-							ResultBox_SelectionChanged(null, null);
-						};
-						bw.RunWorkerAsync(xbox);
-						return;
-					}
-					switch (xbox.AssetType)
-					{
-						case XboxTitleInfo.XboxAssetType.Icon:
-							SetPreview(xbox.GetAsset().Image, 64, 64);
-							PreviewImg.ContextMenu.ItemsSource = _iconMenu;
-							_main.EditMenu.ItemsSource = _iconMenu;
-							break;
-						case XboxTitleInfo.XboxAssetType.Banner:
-							SetPreview(xbox.GetAsset().Image, 420, 96);
-							PreviewImg.ContextMenu.ItemsSource = _bannerMenu;
-							_main.EditMenu.ItemsSource = _bannerMenu;
-							break;
-						case XboxTitleInfo.XboxAssetType.Background:
-							SetPreview(xbox.GetAsset().Image, 1280, 720);
-							PreviewImg.ContextMenu.ItemsSource = _backgroundMenu;
-							_main.EditMenu.ItemsSource = _backgroundMenu;
-							break;
-						case XboxTitleInfo.XboxAssetType.Screenshot:
-							SetPreview(xbox.GetAsset().Image, 1000, 562);
-							PreviewImg.ContextMenu.ItemsSource = _screenshotsMenu;
-							_main.EditMenu.ItemsSource = _screenshotsMenu;
-							break;
-					}
-				} else
-				{
-					var archive = ResultBox.SelectedItem as InternetArchiveAsset;
-					if (archive != null)
-					{
-						if (!archive.HaveAsset)
-						{
-							PreviewImg.Source = null;
-							StatusMessage.Text = "Downloading cover...";
-							var bw = new BackgroundWorker();
-							bw.DoWork += (o, args) =>
-							{
-								var asset = args.Argument as InternetArchiveAsset;
-								if (asset != null)
-									asset.GetCover();
-							};
-							bw.RunWorkerCompleted += (o, args) =>
-							{
-								StatusMessage.Text = "Finished downloading cover...";
-								ResultBox_SelectionChanged(null, null);
-							};
-							bw.RunWorkerAsync(archive);
-						}
-						else
-						{
-							var cover = archive.GetCover();
-							if (cover != null)
-							{
-								SetPreview(cover, 900, 600);
-								PreviewImg.ContextMenu.ItemsSource = _coverMenu;
-								_main.EditMenu.ItemsSource = _coverMenu;
-							}
-							else
-							{
-								PreviewImg.Source = null;
-								PreviewImg.ContextMenu.ItemsSource = null;
-								_main.EditMenu.ItemsSource = null;
-								StatusMessage.Text = "Failed to load cover image.";
-							}
-						}
-					}
+                    if (!xbox.HaveAsset)
+                    {
+                        PreviewImg.Source = null;
+                        StatusMessage.Text = "Downloading asset data...";
+                        var bw = new BackgroundWorker();
+                        bw.DoWork += (o, args) => {
+                            var asset = args.Argument as XboxTitleInfo.XboxAssetInfo;
+                            if (asset != null)
+                                asset.GetAsset();
+                        };
+                        bw.RunWorkerCompleted += (o, args) => {
+                            StatusMessage.Text = "Finished downloading asset data...";
+                            ResultBox_SelectionChanged(null, null);
+                        };
+                        bw.RunWorkerAsync(xbox);
+                        return;
+                    }
+                    switch (xbox.AssetType)
+                    {
+                        case XboxTitleInfo.XboxAssetType.Icon:
+                            SetPreview(xbox.GetAsset().Image, 64, 64);
+                            PreviewImg.ContextMenu.ItemsSource = _iconMenu;
+                            _main.EditMenu.ItemsSource = _iconMenu;
+                            break;
+                        case XboxTitleInfo.XboxAssetType.Banner:
+                            SetPreview(xbox.GetAsset().Image, 420, 96);
+                            PreviewImg.ContextMenu.ItemsSource = _bannerMenu;
+                            _main.EditMenu.ItemsSource = _bannerMenu;
+                            break;
+                        case XboxTitleInfo.XboxAssetType.Background:
+                            SetPreview(xbox.GetAsset().Image, 1280, 720);
+                            PreviewImg.ContextMenu.ItemsSource = _backgroundMenu;
+                            _main.EditMenu.ItemsSource = _backgroundMenu;
+                            break;
+                        case XboxTitleInfo.XboxAssetType.Screenshot:
+                            SetPreview(xbox.GetAsset().Image, 1000, 562);
+                            PreviewImg.ContextMenu.ItemsSource = _screenshotsMenu;
+                            _main.EditMenu.ItemsSource = _screenshotsMenu;
+                            break;
+                    }
+                } else
+                {
+                    var archive = ResultBox.SelectedItem as InternetArchiveAsset;
+                    if (archive != null)
+                    {
+                        if (!archive.HaveAsset)
+                        {
+                            PreviewImg.Source = null;
+                            StatusMessage.Text = "Downloading cover...";
+                            var bw = new BackgroundWorker();
+                            bw.DoWork += (o, args) =>
+                            {
+                                var asset = args.Argument as InternetArchiveAsset;
+                                if (asset != null)
+                                    asset.GetCover();
+                            };
+                            bw.RunWorkerCompleted += (o, args) =>
+                            {
+                                StatusMessage.Text = "Finished downloading cover...";
+                                ResultBox_SelectionChanged(null, null);
+                            };
+                            bw.RunWorkerAsync(archive);
+                        }
+                        else
+                        {
+                            var cover = archive.GetCover();
+                            if (cover != null)
+                            {
+                                SetPreview(cover, 900, 600);
+                                PreviewImg.ContextMenu.ItemsSource = _coverMenu;
+                                _main.EditMenu.ItemsSource = _coverMenu;
+                            }
+                            else
+                            {
+                                PreviewImg.Source = null;
+                                PreviewImg.ContextMenu.ItemsSource = null;
+                                _main.EditMenu.ItemsSource = null;
+                                StatusMessage.Text = "Failed to load cover image.";
+                            }
+                        }
+                    }
 
-				}
+                }
 
-			}
+            }
         }
 
         private void DownloadAllButton_Click(object sender, RoutedEventArgs e)
@@ -476,9 +475,9 @@ namespace AuroraAssetEditor.Controls {
                 return;
             }
 
-			_background.Reset();
-			_iconBanner.Reset();
-			_screenshots.Reset();
+            _background.Reset();
+            _iconBanner.Reset();
+            _screenshots.Reset();
 
             DownloadAllButton.IsEnabled = false;
             StatusMessage.Text = "Downloading all assets...";
@@ -489,9 +488,9 @@ namespace AuroraAssetEditor.Controls {
             bw.DoWork += (s, args) =>
             {
                 int total = assets.Count;
-				int max_ss = 3;
-				int current_ss = 0;
-				int current = 0;
+                int max_ss = 3;
+                int current_ss = 0;
+                int current = 0;
 
                 foreach (var asset in assets)
                 {
@@ -499,15 +498,15 @@ namespace AuroraAssetEditor.Controls {
                     {
                         if (!asset.HaveAsset)
                         {
-							if (asset.AssetType == XboxTitleInfo.XboxAssetType.Screenshot)
-							{
-								if (current_ss >= max_ss)
-								{
-									continue;
-								}
-								current_ss++;
-							}
-							asset.GetAsset();
+                            if (asset.AssetType == XboxTitleInfo.XboxAssetType.Screenshot)
+                            {
+                                if (current_ss >= max_ss)
+                                {
+                                    continue;
+                                }
+                                current_ss++;
+                            }
+                            asset.GetAsset();
                         }
 
                         var image = asset.GetAsset().Image;
@@ -566,7 +565,7 @@ namespace AuroraAssetEditor.Controls {
             bw.RunWorkerAsync();
         }
 
-		private void TitleIdBox_TextChanged(object sender, TextChangedEventArgs e) { TitleIdBox.Text = Regex.Replace(TitleIdBox.Text, "[^a-fA-F0-9]+", ""); }
+        private void TitleIdBox_TextChanged(object sender, TextChangedEventArgs e) { TitleIdBox.Text = Regex.Replace(TitleIdBox.Text, "[^a-fA-F0-9]+", ""); }
 
         private void OnDragEnter(object sender, DragEventArgs e) { _main.OnDragEnter(sender, e); }
 

--- a/AuroraAssetEditor/Controls/ScreenshotsControl.xaml.cs
+++ b/AuroraAssetEditor/Controls/ScreenshotsControl.xaml.cs
@@ -1,9 +1,9 @@
 ﻿//
-// 	ScreenshotsControl.xaml.cs
-// 	AuroraAssetEditor
+//  ScreenshotsControl.xaml.cs
+//  AuroraAssetEditor
 //
-// 	Created by Swizzy on 10/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 10/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor.Controls {
     using System;

--- a/AuroraAssetEditor/Helpers/GlobalState.cs
+++ b/AuroraAssetEditor/Helpers/GlobalState.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Windows;
+using AuroraAssetEditor.Models;
+
+namespace AuroraAssetEditor.Helpers
+{
+	public static class GlobalState
+	{
+		private static Game _currentGame = new Game()
+		{
+			IsGameSelected=false
+		};
+
+		public static event Action GameChanged;
+
+		public static Game CurrentGame
+		{
+			get => _currentGame;
+			set
+			{
+				if (_currentGame != value)
+				{
+					_currentGame = value;
+					GameChanged?.Invoke();
+				}
+			}
+		}
+	}
+
+}
+

--- a/AuroraAssetEditor/Helpers/GlobalState.cs
+++ b/AuroraAssetEditor/Helpers/GlobalState.cs
@@ -4,28 +4,28 @@ using AuroraAssetEditor.Models;
 
 namespace AuroraAssetEditor.Helpers
 {
-	public static class GlobalState
-	{
-		private static Game _currentGame = new Game()
-		{
-			IsGameSelected=false
-		};
+    public static class GlobalState
+    {
+        private static Game _currentGame = new Game()
+        {
+            IsGameSelected=false
+        };
 
-		public static event Action GameChanged;
+        public static event Action GameChanged;
 
-		public static Game CurrentGame
-		{
-			get => _currentGame;
-			set
-			{
-				if (_currentGame != value)
-				{
-					_currentGame = value;
-					GameChanged?.Invoke();
-				}
-			}
-		}
-	}
+        public static Game CurrentGame
+        {
+            get => _currentGame;
+            set
+            {
+                if (_currentGame != value)
+                {
+                    _currentGame = value;
+                    GameChanged?.Invoke();
+                }
+            }
+        }
+    }
 
 }
 

--- a/AuroraAssetEditor/InputDialog.xaml.cs
+++ b/AuroraAssetEditor/InputDialog.xaml.cs
@@ -1,9 +1,9 @@
 ﻿// 
-// 	InputDialog.xaml.cs
-// 	AuroraAssetEditor
+//  InputDialog.xaml.cs
+//  AuroraAssetEditor
 // 
-// 	Created by Swizzy on 07/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 07/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor {
     using System;

--- a/AuroraAssetEditor/MainWindow.xaml
+++ b/AuroraAssetEditor/MainWindow.xaml
@@ -21,8 +21,9 @@
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <Menu Grid.Row="0"
-                VerticalAlignment="Center"
-                Background="White" Grid.ColumnSpan="2">
+                  VerticalAlignment="Center"
+                  Background="White"
+                  Grid.ColumnSpan="2">
                 <MenuItem ContextMenuOpening="FileOpening" Header="File">
                     <MenuItem Click="CreateNewOnClick" Header="Create New Asset File" />
                     <MenuItem Click="LoadAssetOnClick" Header="Load Asset File" />
@@ -52,25 +53,23 @@
                           Header="Edit"
                           SubmenuOpened="EditMenuOpened" />
                 <MenuItem x:Name="GameSelector"
-                    Visibility="Hidden"
-                    Margin="100,0,0,0">
-                    <MenuItem
-                        x:Name="GameTitleIdMenu"
-                        Click="CopyTitleIdToClipboard_Click"
-                        ToolTip="Copies the TitleId to the clipboard"/> 
-                    <MenuItem
-                        x:Name="GameDbIdMenu"
-                        Click="CopyDbIdToClipboard_Click"
-                        ToolTip="Copies the DatabaseID to the clipboard"/>
+                          Visibility="Hidden"
+                          Margin="100,0,0,0">
+                    <MenuItem x:Name="GameTitleIdMenu"
+                              Click="CopyTitleIdToClipboard_Click"
+                              ToolTip="Copies the TitleId to the clipboard"/> 
+                    <MenuItem x:Name="GameDbIdMenu"
+                              Click="CopyDbIdToClipboard_Click"
+                              ToolTip="Copies the DatabaseID to the clipboard"/>
                     <MenuItem Header="Unselect current game"
-                        Click="ClearCurrentGame_Click"
-                        ToolTip="Clear Selection"/>
+                              Click="ClearCurrentGame_Click"
+                              ToolTip="Clear Selection"/>
                 </MenuItem>
             </Menu>
             <TabControl Grid.Row="1"
                         Margin="10"
-                        SelectionChanged="TabChanged"
-                         Grid.ColumnSpan="2">
+                        Grid.ColumnSpan="2"
+                        SelectionChanged="TabChanged">
                 <TabItem x:Name="BoxartTab" Header="Boxart/Cover" />
                 <TabItem x:Name="BackgroundTab" Header="Background" />
                 <TabItem x:Name="IconBannerTab" Header="Icon/Banner" />

--- a/AuroraAssetEditor/MainWindow.xaml
+++ b/AuroraAssetEditor/MainWindow.xaml
@@ -1,6 +1,7 @@
 ﻿<Window x:Class="AuroraAssetEditor.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:AuroraAssetEditor.Helpers"
         xmlns:controls="clr-namespace:AuroraAssetEditor.Controls"
         Title="Aurora Asset Editor v{0}.{1}.{2} by Swizzy thanks to MaesterRowen"
         Width="550"
@@ -11,14 +12,17 @@
         PreviewDragEnter="OnDragEnter">
     <Grid>
         <Grid ZIndex="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="4*"/>
+                <ColumnDefinition Width="7*"/>
+            </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <Menu Grid.Row="0"
-                  HorizontalAlignment="Stretch"
-                  VerticalAlignment="Top"
-                  Background="White">
+                VerticalAlignment="Center"
+                Background="White" Grid.ColumnSpan="2">
                 <MenuItem ContextMenuOpening="FileOpening" Header="File">
                     <MenuItem Click="CreateNewOnClick" Header="Create New Asset File" />
                     <MenuItem Click="LoadAssetOnClick" Header="Load Asset File" />
@@ -47,12 +51,26 @@
                 <MenuItem x:Name="EditMenu"
                           Header="Edit"
                           SubmenuOpened="EditMenuOpened" />
+                <MenuItem x:Name="GameSelector"
+                    Visibility="Hidden"
+                    Margin="100,0,0,0">
+                    <MenuItem
+                        x:Name="GameTitleIdMenu"
+                        Click="CopyTitleIdToClipboard_Click"
+                        ToolTip="Copies the TitleId to the clipboard"/> 
+                    <MenuItem
+                        x:Name="GameDbIdMenu"
+                        Click="CopyDbIdToClipboard_Click"
+                        ToolTip="Copies the DatabaseID to the clipboard"/>
+                    <MenuItem Header="Unselect current game"
+                        Click="ClearCurrentGame_Click"
+                        ToolTip="Clear Selection"/>
+                </MenuItem>
             </Menu>
             <TabControl Grid.Row="1"
                         Margin="10"
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="Stretch"
-                        SelectionChanged="TabChanged">
+                        SelectionChanged="TabChanged"
+                         Grid.ColumnSpan="2">
                 <TabItem x:Name="BoxartTab" Header="Boxart/Cover" />
                 <TabItem x:Name="BackgroundTab" Header="Background" />
                 <TabItem x:Name="IconBannerTab" Header="Icon/Banner" />

--- a/AuroraAssetEditor/MainWindow.xaml.cs
+++ b/AuroraAssetEditor/MainWindow.xaml.cs
@@ -1,9 +1,9 @@
 ﻿//
-// 	MainWindow.xaml.cs
-// 	AuroraAssetEditor
+//  MainWindow.xaml.cs
+//  AuroraAssetEditor
 //
-// 	Created by Swizzy on 08/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 08/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor {
     using System;
@@ -19,8 +19,8 @@ namespace AuroraAssetEditor {
     using System.Windows.Controls;
     using Classes;
     using Models;
-	using Controls;
-	using Helpers;
+    using Controls;
+    using Helpers;
     using Microsoft.Win32;
     using Ookii.Dialogs.Wpf;
     using Image = System.Drawing.Image;
@@ -47,11 +47,12 @@ namespace AuroraAssetEditor {
 
         public MainWindow(IEnumerable<string> args) {
             InitializeComponent();
-			DataContext = GlobalState.CurrentGame;
-			GlobalState.GameChanged += OnGameChanged;  // Ensure the UI gets updated when the game changes
-			var ver = Assembly.GetAssembly(typeof(MainWindow)).GetName().Version;
+            var ver = Assembly.GetAssembly(typeof(MainWindow)).GetName().Version;
             Title = string.Format(Title, ver.Major, ver.Minor, ver.Build);
             Icon = App.WpfIcon;
+            
+            DataContext = GlobalState.CurrentGame;
+            GlobalState.GameChanged += OnGameChanged;  // Ensure the UI gets updated when the game changes
 
             // add support for TLS 1.1 and TLS 1.2
             ServicePointManager.SecurityProtocol = ServicePointManager.SecurityProtocol
@@ -162,18 +163,18 @@ namespace AuroraAssetEditor {
             bw.RunWorkerAsync();
         }
 
-		private void OnGameChanged()
-		{
-			Dispatcher.Invoke(() =>
-			{
+        internal static void SaveError(Exception ex) { File.AppendAllText("error.log", string.Format("[{0}]:{2}{1}{2}", DateTime.Now, ex, Environment.NewLine)); }
+
+        private void OnGameChanged()
+        {
+            Dispatcher.Invoke(() =>
+            {
                 GameSelector.Visibility = GlobalState.CurrentGame.IsGameSelected ? Visibility.Visible : Visibility.Hidden;
                 GameSelector.Header = GlobalState.CurrentGame.Title;
                 GameTitleIdMenu.Header = GlobalState.CurrentGame.TitleId;
                 GameDbIdMenu.Header = GlobalState.CurrentGame.DbId;
             });
-		}
-
-		internal static void SaveError(Exception ex) { File.AppendAllText("error.log", string.Format("[{0}]:{2}{1}{2}", DateTime.Now, ex, Environment.NewLine)); }
+        }
 
         private static void SaveFileError(string file, Exception ex) {
             SaveError(ex);
@@ -352,8 +353,17 @@ namespace AuroraAssetEditor {
             bw.RunWorkerAsync();
         }
 
-		private void ClearCurrentGame_Click(object sender, RoutedEventArgs e)
-		{
+        private void ExitOnClick(object sender, RoutedEventArgs e) { Close(); }
+
+        internal void OnDragEnter(object sender, DragEventArgs e) {
+            if(e.Data.GetDataPresent(DataFormats.FileDrop) && (e.AllowedEffects & DragDropEffects.Copy) == DragDropEffects.Copy)
+                e.Effects = DragDropEffects.Copy;
+            else
+                e.Effects = DragDropEffects.None; // Ignore this one
+        }
+
+        private void ClearCurrentGame_Click(object sender, RoutedEventArgs e)
+        {
             var NewGame = new Game
             {
                 Title = string.Empty,
@@ -364,36 +374,27 @@ namespace AuroraAssetEditor {
             GlobalState.CurrentGame = NewGame;
         }
 
-		private void CopyTitleIdToClipboard_Click(object sender, RoutedEventArgs e)
-		{
-			string titleId = GlobalState.CurrentGame.TitleId;
-			if (!string.IsNullOrEmpty(titleId))
-			{
-				Clipboard.SetText(titleId);
-			}
-		}
+        private void CopyTitleIdToClipboard_Click(object sender, RoutedEventArgs e)
+        {
+            string titleId = GlobalState.CurrentGame.TitleId;
+            if (!string.IsNullOrEmpty(titleId))
+            {
+                Clipboard.SetText(titleId);
+            }
+        }
 
-		private void CopyDbIdToClipboard_Click(object sender, RoutedEventArgs e)
-		{
-			string DbID = GlobalState.CurrentGame.DbId;
-			if (!string.IsNullOrEmpty(DbID))
-			{
-				Clipboard.SetText(DbID);
-			}
-		}
+        private void CopyDbIdToClipboard_Click(object sender, RoutedEventArgs e)
+        {
+            string DbID = GlobalState.CurrentGame.DbId;
+            if (!string.IsNullOrEmpty(DbID))
+            {
+                Clipboard.SetText(DbID);
+            }
+        }
 
-		private void ExitOnClick(object sender, RoutedEventArgs e) { Close(); }
-
-		private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
-		{
-			GlobalState.GameChanged -= OnGameChanged;
-		}
-
-		internal void OnDragEnter(object sender, DragEventArgs e) {
-            if(e.Data.GetDataPresent(DataFormats.FileDrop) && (e.AllowedEffects & DragDropEffects.Copy) == DragDropEffects.Copy)
-                e.Effects = DragDropEffects.Copy;
-            else
-                e.Effects = DragDropEffects.None; // Ignore this one
+        private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            GlobalState.GameChanged -= OnGameChanged;
         }
 
         private Image GetImage(string filename, Size newSize) {

--- a/AuroraAssetEditor/Models/Game.cs
+++ b/AuroraAssetEditor/Models/Game.cs
@@ -7,43 +7,43 @@ using System.Threading.Tasks;
 
 namespace AuroraAssetEditor.Models
 {
-	public class Game : INotifyPropertyChanged
-	{
-		private string _title;
-		private string _titleId;
-		private string _dbId;
-		private bool _isGameSelected;
+    public class Game : INotifyPropertyChanged
+    {
+        private string _title;
+        private string _titleId;
+        private string _dbId;
+        private bool _isGameSelected;
 
-		public string Title
-		{
-			get => _title;
-			set { _title = value; OnPropertyChanged(Title); }
-		}
+        public string Title
+        {
+            get => _title;
+            set { _title = value; OnPropertyChanged(Title); }
+        }
 
-		public string TitleId
-		{
-			get => _titleId;
-			set { _titleId = value; OnPropertyChanged(TitleId); }
-		}
+        public string TitleId
+        {
+            get => _titleId;
+            set { _titleId = value; OnPropertyChanged(TitleId); }
+        }
 
-		public string DbId
-		{
-			get => _dbId;
-			set { _dbId = value; OnPropertyChanged(DbId); }
-		}
+        public string DbId
+        {
+            get => _dbId;
+            set { _dbId = value; OnPropertyChanged(DbId); }
+        }
 
-		public bool IsGameSelected
-		{
-			get => _isGameSelected;
-			set { _isGameSelected = value; OnPropertyChanged(nameof(IsGameSelected)); }
-		}
+        public bool IsGameSelected
+        {
+            get => _isGameSelected;
+            set { _isGameSelected = value; OnPropertyChanged(nameof(IsGameSelected)); }
+        }
 
-		public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler PropertyChanged;
 
-		protected void OnPropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
-		{
-			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-		}
-	}
+        protected void OnPropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
 
 }

--- a/AuroraAssetEditor/Models/Game.cs
+++ b/AuroraAssetEditor/Models/Game.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AuroraAssetEditor.Models
+{
+	public class Game : INotifyPropertyChanged
+	{
+		private string _title;
+		private string _titleId;
+		private string _dbId;
+		private bool _isGameSelected;
+
+		public string Title
+		{
+			get => _title;
+			set { _title = value; OnPropertyChanged(Title); }
+		}
+
+		public string TitleId
+		{
+			get => _titleId;
+			set { _titleId = value; OnPropertyChanged(TitleId); }
+		}
+
+		public string DbId
+		{
+			get => _dbId;
+			set { _dbId = value; OnPropertyChanged(DbId); }
+		}
+
+		public bool IsGameSelected
+		{
+			get => _isGameSelected;
+			set { _isGameSelected = value; OnPropertyChanged(nameof(IsGameSelected)); }
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		protected void OnPropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+	}
+
+}

--- a/AuroraAssetEditor/TitleAndDbIdDialog.xaml.cs
+++ b/AuroraAssetEditor/TitleAndDbIdDialog.xaml.cs
@@ -11,13 +11,16 @@ namespace AuroraAssetEditor {
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Input;
+	using AuroraAssetEditor.Helpers;
 
-    public partial class TitleAndDbIdDialog {
+	public partial class TitleAndDbIdDialog {
         public TitleAndDbIdDialog(Window owner) {
             InitializeComponent();
             Icon = App.WpfIcon;
             Owner = owner;
-        }
+			TitleIdBox.Text = GlobalState.CurrentGame.TitleId;
+			DbIdBox.Text = GlobalState.CurrentGame.DbId;
+		}
 
         public string TitleId { get { return TitleIdBox.Text; } }
 
@@ -33,7 +36,7 @@ namespace AuroraAssetEditor {
         private void OnTextChanged(object sender, TextChangedEventArgs e) {
             TitleIdBox.Text = Regex.Replace(TitleIdBox.Text, "[^a-fA-F0-9]+", "");
             DbIdBox.Text = Regex.Replace(DbIdBox.Text, "[^a-fA-F0-9]+", "");
-            OkButton.IsEnabled = TitleIdBox.Text.Length == 8 && DbIdBox.Text.Length == 8;
+           OkButton.IsEnabled = TitleIdBox.Text.Length == 8 && DbIdBox.Text.Length == 8;
         }
     }
 }

--- a/AuroraAssetEditor/TitleAndDbIdDialog.xaml.cs
+++ b/AuroraAssetEditor/TitleAndDbIdDialog.xaml.cs
@@ -1,9 +1,9 @@
 ﻿// 
-// 	TitleAndDbIdDialog.xaml.cs
-// 	AuroraAssetEditor
+//  TitleAndDbIdDialog.xaml.cs
+//  AuroraAssetEditor
 // 
-// 	Created by Swizzy on 10/05/2015
-// 	Copyright (c) 2015 Swizzy. All rights reserved.
+//  Created by Swizzy on 10/05/2015
+//  Copyright (c) 2015 Swizzy. All rights reserved.
 
 namespace AuroraAssetEditor {
     using System.Globalization;
@@ -11,16 +11,16 @@ namespace AuroraAssetEditor {
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Input;
-	using AuroraAssetEditor.Helpers;
+    using AuroraAssetEditor.Helpers;
 
-	public partial class TitleAndDbIdDialog {
+    public partial class TitleAndDbIdDialog {
         public TitleAndDbIdDialog(Window owner) {
             InitializeComponent();
             Icon = App.WpfIcon;
             Owner = owner;
-			TitleIdBox.Text = GlobalState.CurrentGame.TitleId;
-			DbIdBox.Text = GlobalState.CurrentGame.DbId;
-		}
+            TitleIdBox.Text = GlobalState.CurrentGame.TitleId;
+            DbIdBox.Text = GlobalState.CurrentGame.DbId;
+        }
 
         public string TitleId { get { return TitleIdBox.Text; } }
 
@@ -36,7 +36,7 @@ namespace AuroraAssetEditor {
         private void OnTextChanged(object sender, TextChangedEventArgs e) {
             TitleIdBox.Text = Regex.Replace(TitleIdBox.Text, "[^a-fA-F0-9]+", "");
             DbIdBox.Text = Regex.Replace(DbIdBox.Text, "[^a-fA-F0-9]+", "");
-           OkButton.IsEnabled = TitleIdBox.Text.Length == 8 && DbIdBox.Text.Length == 8;
+            OkButton.IsEnabled = TitleIdBox.Text.Length == 8 && DbIdBox.Text.Length == 8;
         }
     }
 }


### PR DESCRIPTION
Here is some features that I have added and find useful while using this wonderful tool:
## Current Game
Whenever I tried to look for a game or send it to my console, I always had to look for the titleID and copy it manually. Now, you can select a game from the Table, and then it will automatically fill the necessary forms

![image](https://github.com/user-attachments/assets/36b42c81-d028-415b-8857-24436101ad71)
![image](https://github.com/user-attachments/assets/ee6d0aa2-cf84-4b3d-a5c8-2553ef24582f)

*Note: when you click in the titleID or databaseID, it also gets copied to your clipboard

## Internet Archive
Since I just modded my console, I found out that `xboxunity.net` is currently down. So instead of doing everything manually, I have added a new source from [Internet Archive Dump](https://archive.org/download/xboxunity-covers-fulldump_202311/xboxunity-covers-fulldump/4156004D/)

![image](https://github.com/user-attachments/assets/1a6ccc2f-d593-4519-81ed-3126ccb04d63)

## Apply All for `Xbox.com`

Also, since I am lazy, I have added a button that *automatically* applies all assets from the xbox.com search result (with a max of 3 ss)

![image](https://github.com/user-attachments/assets/c5ffc010-2b77-426c-b6a2-92cf8c2128ac)

## 

This changes should improve the workflow of people using the tool (myself included)

